### PR TITLE
Update Java version to 21 and change log encoding to UTF-8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 	<name>demo</name>
 	<description>Demo project for Spring Boot</description>
 	<properties>
-		<java.version>17</java.version>
+		<java.version>21</java.version>
 	</properties>
 	<dependencies>
 

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
     <property name="LOG_PATTERN" value="[%d{yyyy-MM-dd HH:mm:ss}][%level][%14t]%25C{1} - %m%n" />
-    <property name="LOG_ENCODING" value="MS950" />
+    <property name="LOG_ENCODING" value="UTF8" />
 
     <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>


### PR DESCRIPTION
Upgrade the Java version in the project configuration and update the log encoding to ensure compatibility and improved character support.