### PR TITLE
Remove push trigger condition for master branch in workflow

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -2,8 +2,6 @@ name: Create Release
 
 on:
   push:
-    branches:
-      - master
     tags:
       - "v*.*.*"
 


### PR DESCRIPTION
Eliminate the push trigger for the master branch in the release workflow.