### PR TITLE
ci: Update Maven build command in CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
           cache: "maven"
 
       - name: Build with Maven (skip tests)
-        run: mvn package -DskipTests
+        run: mvn clean package -DskipTests
 
       - name: Run Java
         run: java -cp target/classes com.vance.demo.tool.Test


### PR DESCRIPTION
Modify the CI workflow to use `mvn clean package` instead of `mvn package -DskipTests` for a cleaner build process.