### PR TITLE
Add translation workflow and file hash calculation in tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,8 +18,26 @@ jobs:
           java-version: "21"
           cache: "maven"
 
+      - name: Grant execute permission to mvnw
+        run: chmod +x mvnw
+
       - name: Build with Maven (skip tests)
-        run: mvn clean compile dependency:copy-dependencies
+        run: ./mvnw clean compile dependency:copy-dependencies
 
       - name: Run Java
         run: java -cp "target/classes:target/dependency/*" com.vance.demo.tool.MarkdownToHtml
+
+      # - name: Convert Markdown to PDF
+      # - uses: baileyjm02/markdown-to-pdf@v1
+      #   with:
+      #     input_dir: docs
+      #     output_dir: pdfs
+      #     images_dir: docs/images
+      #     # for example <img src="./images/file-name.png">
+      #     image_import: ./images
+      #     # Default is true, can set to false to only get PDF files
+      #     build_html: false
+      # - uses: actions/upload-artifact@v4
+      #   with:
+      #     name: docs
+      #     path: pdfs

--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -1,0 +1,34 @@
+name: Translate Project
+
+on:
+  workflow_dispatch: # 可以手動執行此 action
+
+jobs:
+  translate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.10"
+
+      - name: Cache pip
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install co-op-translator
+
+      - name: Run translation
+        run: |
+          translate -l "tw zh"

--- a/pom.xml
+++ b/pom.xml
@@ -36,11 +36,6 @@
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-data-jpa</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
 
@@ -57,11 +52,16 @@
 			<scope>test</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-jpa</artifactId>
+		</dependency>
+
 		<!-- ================ Spring 必要 ================ -->
 		<dependency>
 			<groupId>org.aspectj</groupId>
 			<artifactId>aspectjweaver</artifactId>
-			<version>1.9.19</version>
+			<version>1.9.22.1</version>
 		</dependency>
 
 		<dependency>
@@ -87,6 +87,12 @@
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
 			<version>2.18.0</version>
+		</dependency>
+
+		<dependency>
+			<groupId>commons-codec</groupId>
+			<artifactId>commons-codec</artifactId>
+			<version>1.18.0</version>
 		</dependency>
 
 		<!-- ========== 常用Third-Party Library ========== -->

--- a/src/test/java/com/vance/demo/test/VanceTest.java
+++ b/src/test/java/com/vance/demo/test/VanceTest.java
@@ -1,21 +1,59 @@
 package com.vance.demo.test;
 
-import java.util.function.Predicate;
+import java.io.File;
+import java.io.FileInputStream;
 
+import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.SystemUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
+
+import com.google.common.hash.Hashing;
+import com.google.common.io.Files;
 
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class VanceTest {
     public static void main(String[] args) {
-        log.info("vance test start");
+        log.info("========== {} 開始 ==========", VanceTest.class.getSimpleName());
         try {
-            Predicate<Integer> isEven = n -> n % 2 == 0;
-            log.info("{}", isEven.test(10));
+            File file = FileUtils.getFile(SystemUtils.getUserHome(), "Desktop", "新文件 1.html");
+            log.info("SHA-256 Hash: {}", VanceTest.getFileHashByGuava(file));
+            log.info("SHA-256 Hash: {}", VanceTest.getFileHashByApache(file));
         } catch (Exception e) {
             log.error("{}", ExceptionUtils.getStackTrace(e));
         }
-        log.info("vance test end");
+        log.info("========== {} 結束 ==========", VanceTest.class.getSimpleName());
+    }
+
+    /**
+     * 使用 Guava 來計算檔案的 SHA-256 Hash
+     * 
+     * @param file
+     * @return
+     */
+    public static String getFileHashByGuava(File file) {
+        log.info("File Path: {}", file.getAbsolutePath());
+        try {
+            return Files.asByteSource(file).hash(Hashing.sha256()).toString();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * 使用 Apache Commons Codec 來計算檔案的 SHA-256 Hash
+     * 
+     * @param file
+     * @return
+     */
+    public static String getFileHashByApache(File file) {
+        log.info("File Path: {}", file.getAbsolutePath());
+        try (FileInputStream fis = new FileInputStream(file)) {
+            return DigestUtils.sha256Hex(fis);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 }


### PR DESCRIPTION
- 在測試工作流程中，將 Maven 命令改為使用可執行的 mvnw。
- 新增使用 Guava 和 Apache Commons Codec 計算檔案 SHA-256 雜湊的功能。
- 移除不必要的依賴項，並更新相關依賴的版本。